### PR TITLE
Refactor to use a single bucket

### DIFF
--- a/registry/storage/driver/driver.go
+++ b/registry/storage/driver/driver.go
@@ -262,10 +262,26 @@ func (d *driver) List(ctx context.Context, path string) ([]string, error) {
 		return nil, err
 	}
 
-	files := make([]string, len(objs))
+	files := make([]string, 0)
 	for i := range objs {
-		files[i] = filepath.Join(path, objs[i].Name)
+		if strings.HasPrefix(objs[i].Name, path) {
+			idx := strings.Index(objs[i].Name[len(path):], "/")
+			files = append(files, filepath.Join(path, objs[i].Name[len(path):idx+1]))
+		}
 	}
+
+	if len(files) == 0 {
+		return nil, storagedriver.PathNotFoundError{Path: path}
+	}
+
+	// keys := make(map[string]bool)
+	// distinct := make([]string, 0)
+	// for i := range files {
+	// 	if _, v := keys[files[i]]; !v {
+	// 		keys[files[i]] = true
+	// 		distinct = append(distinct, files[i])
+	// 	}
+	// }
 
 	return files, nil
 }

--- a/registry/storage/driver/driver.go
+++ b/registry/storage/driver/driver.go
@@ -273,9 +273,14 @@ func (d *driver) List(ctx context.Context, path string) ([]string, error) {
 	}
 
 	objs, err := store.List(ctx)
-	if errors.Is(err, jetstream.ErrNoObjectsFound) {
+	// TODO: Remove this when workaround obj is removed
+	if len(objs) == 1 && path == "/" {
 		return []string{}, nil
 	}
+	// TODO: This is what it should be.
+	// if errors.Is(err, jetstream.ErrNoObjectsFound) {
+	// 	return []string{}, nil
+	// }
 	if err != nil {
 		return nil, err
 	}

--- a/registry/storage/driver/driver.go
+++ b/registry/storage/driver/driver.go
@@ -265,8 +265,15 @@ func (d *driver) List(ctx context.Context, path string) ([]string, error) {
 	files := make([]string, 0)
 	for i := range objs {
 		if strings.HasPrefix(objs[i].Name, path) {
-			idx := strings.Index(objs[i].Name[len(path):], "/")
-			files = append(files, filepath.Join(path, objs[i].Name[len(path):idx+1]))
+			start := len(path) + 1
+			if path == "/" {
+				start = 1
+			}
+			idx := strings.Index(objs[i].Name[start:], "/")
+			if idx == -1 {
+				idx = len(objs[i].Name) - start
+			}
+			files = append(files, filepath.Join(path, objs[i].Name[len(path):start+idx]))
 		}
 	}
 
@@ -274,16 +281,16 @@ func (d *driver) List(ctx context.Context, path string) ([]string, error) {
 		return nil, storagedriver.PathNotFoundError{Path: path}
 	}
 
-	// keys := make(map[string]bool)
-	// distinct := make([]string, 0)
-	// for i := range files {
-	// 	if _, v := keys[files[i]]; !v {
-	// 		keys[files[i]] = true
-	// 		distinct = append(distinct, files[i])
-	// 	}
-	// }
+	keys := make(map[string]bool)
+	distinct := make([]string, 0)
+	for i := range files {
+		if _, v := keys[files[i]]; !v {
+			keys[files[i]] = true
+			distinct = append(distinct, files[i])
+		}
+	}
 
-	return files, nil
+	return distinct, nil
 }
 
 // Move moves an object stored at sourcePath to destPath, removing the

--- a/registry/storage/driver/driver.go
+++ b/registry/storage/driver/driver.go
@@ -143,7 +143,7 @@ func (d *driver) PutContent(ctx context.Context, path string, content []byte) er
 			return err
 		}
 	} else {
-		// Zero-byte content is a special case, it may appended to later.
+		// Zero-byte content is a special case, it may be appended to later.
 		fw, err := d.Writer(ctx, path, false)
 		if err != nil {
 			return err
@@ -291,11 +291,11 @@ func (d *driver) List(ctx context.Context, path string) ([]string, error) {
 			if path == "/" {
 				start = 1
 			}
-			idx := strings.Index(objs[i].Name[start:], "/")
-			if idx == -1 {
-				idx = len(objs[i].Name) - start
+			end := strings.Index(objs[i].Name[start:], "/")
+			if end == -1 {
+				end = len(objs[i].Name) - start
 			}
-			files = append(files, filepath.Join(path, objs[i].Name[len(path):start+idx]))
+			files = append(files, filepath.Join(path, objs[i].Name[len(path):start+end]))
 		}
 	}
 

--- a/registry/storage/driver/driver.go
+++ b/registry/storage/driver/driver.go
@@ -365,13 +365,19 @@ func (d *driver) Delete(ctx context.Context, path string) error {
 		return err
 	}
 
+	deleted := false
 	for i := range objects {
-		if strings.HasPrefix(objects[i].Name, path) {
+		if strings.HasPrefix(objects[i].Name, path+"/") {
 			err := store.Delete(ctx, objects[i].Name)
 			if err != nil {
 				return err
 			}
+			deleted = true
 		}
+	}
+
+	if !deleted {
+		return storagedriver.PathNotFoundError{Path: path}
 	}
 
 	return nil

--- a/registry/storage/driver/file_writer.go
+++ b/registry/storage/driver/file_writer.go
@@ -33,8 +33,8 @@ func newFileWriter(ctx context.Context, store jetstream.ObjectStore, name string
 
 	if append {
 		info, err := fw.obs.GetInfo(fw.ctx, fw.name)
-		if err == nil && info.Size != 0 {
-			return nil, errors.New("file already exists and is not zero-length")
+		if err == nil && !isLink(info) {
+			return nil, errors.New("file already exists and is not a link")
 		}
 
 		for {


### PR DESCRIPTION
The first working implementation used buckets to represent directories. This was easy to implement and efficient while testing. Unfortunately, Distribution creates a _lot_ of different directories. Pushing the `python:3` image to a fresh registry creates about 50 buckets. The problem is that every bucket creation on a JetStream cluster results in a leader election, which can take up to half a second per bucket. That brings uploading the `python:3` image to a crawl, taking over 40 seconds.

Refactoring to use a single bucket instead solves this particular issue. Going to write a design on how to optimize this further.